### PR TITLE
fix: ensure bash is used for `idc` script

### DIFF
--- a/idc
+++ b/idc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "$MANAGER" ] || ! which $MANAGER; then
 	if which docker 2>/dev/null; then


### PR DESCRIPTION
`idc` uses `$RANDOM`, which is a bashism. Running it from a non-bash shell will fail as this pseudo-variable will return nothing.